### PR TITLE
[libc][math] Refactor frexpf128 implementation to header-only in src/__support/math folder.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -13,5 +13,6 @@
 
 #include "math/expf.h"
 #include "math/expf16.h"
+#include "math/frexpf128.h"
 
 #endif // LLVM_LIBC_SHARED_MATH_H

--- a/libc/shared/math/frexpf128.h
+++ b/libc/shared/math/frexpf128.h
@@ -1,4 +1,4 @@
-//===-- Implementation of frexpf128 function ------------------------------===//
+//===-- Shared frexpf128 function -------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,14 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/frexpf128.h"
+#ifndef LLVM_LIBC_SHARED_MATH_FREXPF128_H
+#define LLVM_LIBC_SHARED_MATH_FREXPF128_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/frexpf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(float128, frexpf128, (float128 x, int *exp)) {
-  return math::frexpf128(x, exp);
-}
+using math::frexpf128;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_FREXPF128_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -50,3 +50,12 @@ add_header_library(
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
 )
+
+add_header_library(
+  frexpf128
+  HDRS
+    frexpf128.h
+  DEPENDS
+    libc.src.__support.macros.properties.types
+    libc.src.__support.FPUtil.manipulation_functions
+)

--- a/libc/src/__support/math/frexpf128.h
+++ b/libc/src/__support/math/frexpf128.h
@@ -1,0 +1,28 @@
+//===-- Implementation header for expf16 ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_EXPF16_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_EXPF16_H
+
+#include "src/__support/FPUtil/ManipulationFunctions.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+static constexpr float128 frexpf128(float128 x, int *exp) {
+  return fputil::frexp(x, *exp);
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_EXPF16_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1774,8 +1774,7 @@ add_entrypoint_object(
   HDRS
     ../frexpf128.h
   DEPENDS
-    libc.src.__support.macros.properties.types
-    libc.src.__support.FPUtil.manipulation_functions
+    libc.src.__support.math.frexpf128
 )
 
 add_entrypoint_object(

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2124,6 +2124,15 @@ libc_support_library(
     ],
 )
 
+libc_support_library(
+    name = "__support_math_frexpf128",
+    hdrs = ["src/__support/math/frexpf128.h"],
+    deps = [
+        ":__support_macros_properties_types",
+        ":__support_fputil_manipulation_functions",
+    ],
+)
+
 ############################### complex targets ################################
 
 libc_function(


### PR DESCRIPTION
**Stack**:
- #4 ⬅
- #3
- #2
- #1


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*